### PR TITLE
fix: Today selection not always available

### DIFF
--- a/src/qlik-date-picker.js
+++ b/src/qlik-date-picker.js
@@ -210,9 +210,9 @@ define(["qlik", "jquery", "./lib/moment.min", "./calendar-settings", "./lib/enco
                 var minDate, maxDate, startDate, endDate;
                 moment.locale(layout.props.locale);
                 minDate = createMoment(layout.props.minDate, qlikDateFormat);
-                maxDate = createMoment(layout.props.maxDate, qlikDateFormat);
+                maxDate = createMoment(layout.props.maxDate, qlikDateFormat).endOf("day");
                 startDate = createMoment(layout.props.startDate, qlikDateFormat);
-                endDate = createMoment(layout.props.endDate, qlikDateFormat);
+                endDate = createMoment(layout.props.endDate, qlikDateFormat).endOf("day");
                 $('#dropDown_' + layout.qInfo.qId).remove();
 
                 $element.html(createHtml(this.dateStates, outDateFormat, layout.props, sortAscending));


### PR DESCRIPTION
Sometimes the date picker will not let a user select the "Today" option, even though today's date is possible in the selection.

The source of the issue is that the maxDate is being set to the beginning of today rather than the end, which then marks "today" as an invalid option. By changing maxDate and endDate to use the end of the day as their timestamp, the validation range becomes inclusive of the maxDate and endDates

Before, Today is not clickable:
![image](https://user-images.githubusercontent.com/5554373/118178059-8092bf80-b401-11eb-90b9-74deff5ae482.png)


After, Today is clickable:
![image](https://user-images.githubusercontent.com/5554373/118178106-8e484500-b401-11eb-9834-f77365836288.png)

I've confirmed that pressing "Today" selects the correct day.